### PR TITLE
Changed const meta to let meta

### DIFF
--- a/plugin_manager.plugin.stf.js
+++ b/plugin_manager.plugin.stf.js
@@ -1,5 +1,5 @@
 // Metadata
-const meta_plugin_manager = {
+let meta_plugin_manager = {
     id: 'ml.crafterpika.pluginmanager69', // ID's should be a unique string
     name: 'PluginManager',
     author: 'CrafterPika',


### PR DESCRIPTION
Setting meta to let instead of const fixes redeclaration issues. A plugin must be capable of being ran multiple times without causing an error. In some edge cases a plugin may be ran multiple times in a single page load. This is why everything a plugin executes must be inside `window['start_' + meta_plugin_manager.id] = function(){}`.